### PR TITLE
initialize value

### DIFF
--- a/src/match/rdj-spmproc.c
+++ b/src/match/rdj-spmproc.c
@@ -105,6 +105,7 @@ static void outproc_a(GT_UNUSED GtUword suffix_seqnum,
         skipped = true;\
         d.out.e.proc = outproc;\
         d.out.e.data = &skipped;\
+        d.skipped_counter = 0;\
         gt_spmproc_skip((SN), (PN), 100UL, false, true, &d);\
         if (EXP) gt_ensure(skipped);\
         else gt_ensure(!skipped);\

--- a/src/match/rdj-spmproc.h
+++ b/src/match/rdj-spmproc.h
@@ -56,7 +56,6 @@ Given a GtBitsequence (large as the number of reads), acts as a filter
 and calls the Spmproc outproc if the bit for both seqnums is not set.
 The void* data must be of type GtSpmprocSkipData.
 */
-
 typedef struct {
   GtBitsequence *to_skip;
   GtSpmprocXWithData out;

--- a/src/match/rdj-strgraph.c
+++ b/src/match/rdj-strgraph.c
@@ -739,6 +739,7 @@ int gt_strgraph_load_spm_from_file(GtStrgraph *strgraph,
     skipdata.out.e.proc = gt_spmproc_strgraph_add;
     skipdata.to_skip = contained;
     skipdata.out.e.data = strgraph;
+    skipdata.skipped_counter = 0;
   }
   strgraph->load_self_spm = load_self_spm;
   for (i = 0; i < nspmfiles; i++)

--- a/src/tools/gt_readjoiner_asqg.c
+++ b/src/tools/gt_readjoiner_asqg.c
@@ -148,6 +148,7 @@ static int gt_readjoiner_asqg_use_spmfiles(GtSpmproc proc, void *procdata,
     skipdata.to_skip = contained;
     skipdata.out.e.proc = proc;
     skipdata.out.e.data = procdata;
+    skipdata.skipped_counter = 0;
   }
   for (i = 0; i < nspmfiles; i++)
   {

--- a/src/tools/gt_readjoiner_assembly.c
+++ b/src/tools/gt_readjoiner_assembly.c
@@ -271,6 +271,7 @@ static int gt_readjoiner_assembly_count_spm(const char *readset, bool eqlen,
     skipdata.out.e.proc = gt_spmproc_strgraph_count;
     skipdata.to_skip = contained;
     skipdata.out.e.data = strgraph;
+    skipdata.skipped_counter = 0;
   }
   for (i = 0; i < nspmfiles; i++)
   {

--- a/src/tools/gt_readjoiner_gfa.c
+++ b/src/tools/gt_readjoiner_gfa.c
@@ -155,6 +155,7 @@ static int gt_readjoiner_gfa_use_spmfiles(GtSpmproc proc, void *procdata,
     skipdata.to_skip = contained;
     skipdata.out.e.proc = proc;
     skipdata.out.e.data = procdata;
+    skipdata.skipped_counter = 0;
   }
   for (i = 0; i < nspmfiles; i++)
   {


### PR DESCRIPTION
This PR introduces the following changes:

  - fixes usage of unitialized values


scan-build complained about unitialized value in struct.

This probably should be investigated by the original developer, the value in question is never used
anywhere, maybe it can be removed?